### PR TITLE
Add webpage dashboard for enrollment analysis.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Pioneer Opt-in Enrollment</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/metrics-graphics/2.11.0/metricsgraphics.css">
+    <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
+    <style>
+      .container {
+        max-width: 960px;
+        margin: 0 auto;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Pioneer Opt-in Enrollment</h1>
+      <p>
+        <a href="https://support.mozilla.org/en-US/kb/about-firefox-pioneer">Pioneer</a> is an
+        experimental cohort of users who have opted-in to contiributing sensitive data that helps us
+        understand the Web, how people interact with it, and how people use their browsers.
+      </p>
+      <h2>Enrollment</h2>
+      <p>Number of daily active users with the opt-in add-on installed.</p>
+      <div id="enrollment-graph"></div>
+    </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.11.0/d3.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/metrics-graphics/2.11.0/metricsgraphics.js"></script>
+    <script>
+    (async () => {
+      //const response = await fetch('https://pipeline-cep.prod.mozaws.net/dashboard_output/analysis.Osmose.pioneer_opt_in_estimates.pioneer_opt_in_count.json');
+      //const rawData = await response.json();
+      const rawData = {"20171004":5319,"20171005":5860,"20171006":6846,"20171008":5610,"20171007":6465,"20171003":485};
+      let data = Object.entries(rawData).map(([key, value]) => {
+        return {
+          date: key,
+          value,
+        };
+      });
+      data = data.slice(1, -1); // Remove first and last data points since they're inaccurate
+      data = MG.convert.date(data, 'date', '%Y%m%d');
+
+      MG.data_graphic({
+        title: 'Enrollment',
+        data,
+        width: 600,
+        height: 300,
+        target: '#enrollment-graph',
+        x_accessor: 'date',
+        y_accessor: 'value',
+      });
+    })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
@trink The Pioneer output at https://pipeline-cep.prod.mozaws.net/dashboard_output/analysis.Osmose.pioneer_opt_in_estimates.pioneer_opt_in_count.json doesn't have [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) headers, which means I can't make a dashboard that pulls the data (since the browser blocks the cross-origin request). Is there any way to change the headers of the output file?